### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ python-gyazo
    :target: https://travis-ci.org/ymyzk/python-gyazo
    :alt: Build Status
 .. image:: https://readthedocs.org/projects/python-gyazo/badge/?version=latest
-   :target: http://python-gyazo.readthedocs.org/
+   :target: https://python-gyazo.readthedocs.io/
    :alt: Documentation Status
 .. image:: https://codeclimate.com/github/ymyzk/python-gyazo/badges/gpa.svg
    :target: https://codeclimate.com/github/ymyzk/python-gyazo
@@ -89,6 +89,6 @@ License
 -------
 MIT License. Please see `LICENSE`_.
 
-.. _Read the Docs: http://python-gyazo.readthedocs.org/
-.. _this page: http://python-gyazo.readthedocs.org/en/stable/backup.html
+.. _Read the Docs: https://python-gyazo.readthedocs.io/
+.. _this page: https://python-gyazo.readthedocs.io/en/stable/backup.html
 .. _LICENSE: LICENSE


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.